### PR TITLE
fix(release): harden release.ps1 manifest date handling under WinPS 5.1

### DIFF
--- a/scripts/build-cumulative-manifest.ps1
+++ b/scripts/build-cumulative-manifest.ps1
@@ -1,4 +1,4 @@
-param(
+﻿param(
     [Parameter(Mandatory = $true)]
     [ValidatePattern('^\d+\.\d+\.\d+$')]
     [string]$FromVersion,

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -1,4 +1,4 @@
-param(
+﻿param(
     [Parameter(Mandatory = $true, Position = 0)]
     [ValidateSet('prepare', 'verify', 'publish')]
     [string]$Action,
@@ -123,15 +123,17 @@ function Upsert-ManifestTableField {
         throw "Could not find manifest version table to insert field '$FieldName'."
     }
 
-    return [regex]::Replace(
-        $ManifestText,
-        $headerTablePattern,
-        [System.Text.RegularExpressions.MatchEvaluator]{
-            param($match)
-            $match.Value + "`r`n| $FieldName | $FieldValue |"
-        },
-        1
-    )
+    # Replace only the FIRST header table (the version-info table).
+    # NOTE: the static [regex]::Replace(input, pattern, evaluator, <int>) overload
+    # interprets the trailing int as RegexOptions (1 = IgnoreCase), NOT a match
+    # count — so it would insert the row into EVERY table in the file. Use the
+    # instance .Replace(input, evaluator, count) overload to limit to one.
+    $tableRegex = [regex]::new($headerTablePattern)
+    $evaluator = [System.Text.RegularExpressions.MatchEvaluator]{
+        param($match)
+        $match.Value + "`r`n| $FieldName | $FieldValue |"
+    }
+    return $tableRegex.Replace($ManifestText, $evaluator, 1)
 }
 
 function Get-ManifestTableField {
@@ -279,7 +281,9 @@ function Invoke-Prepare {
     }
 
     $previousVersion = Get-PreviousReleaseVersion -TargetVersion $VersionValue
-    Set-Content -Path $versionFile -Value $VersionValue -Encoding utf8
+    # Write VERSION as BOM-less UTF-8 with LF. WinPS 5.1's `Set-Content -Encoding utf8`
+    # prepends a BOM, which shows up as spurious churn; pin the encoding explicitly.
+    [System.IO.File]::WriteAllText($versionFile, "$VersionValue`n", (New-Object System.Text.UTF8Encoding($false)))
     foreach ($manifest in $frameworkManifests) {
         Update-ManifestHeader -Path $manifest.Path -VersionValue $VersionValue -FromVersionValue $previousVersion -DateFieldName $manifest.DateField
         & (Join-Path $scriptRoot 'update-manifest-cumulative.ps1') -Lang $manifest.Lang -TargetVersion $VersionValue

--- a/scripts/update-manifest-cumulative.ps1
+++ b/scripts/update-manifest-cumulative.ps1
@@ -1,4 +1,4 @@
-param(
+﻿param(
     [ValidateSet('ko', 'en')]
     [string]$Lang = 'ko',
 


### PR DESCRIPTION
`release.ps1 prepare` corrupted the Korean manifest when run via `powershell.exe` (Windows PowerShell 5.1) on a non-UTF-8 (e.g. CP949) console — it scattered garbage `| <mojibake> | <date> |` rows across **every** table in `frameworks/ko/.cowork/upgrade_manifest.md`. CI (`pwsh` 7) was unaffected, so this only bit local runs.

## Root causes
1. **UTF-8-without-BOM `.ps1` read as ANSI on WinPS 5.1** → the Korean literals `날짜` (DateField) and `변경 요약` (cumulative summary matcher) were mojibaked and never matched their target rows. Fixed by adding a UTF-8 BOM to the three scripts that contain non-ASCII literals (`release.ps1`, `update-manifest-cumulative.ps1`, `build-cumulative-manifest.ps1`).
2. **`RegexOptions` mistaken for a match count** — `Upsert-ManifestTableField`'s fallback called `[regex]::Replace(input, pattern, evaluator, 1)`, where the trailing `1` binds to the `RegexOptions` overload (`IgnoreCase`), **not** a count — so a not-found field was inserted into *every* markdown table. Switched to the instance `Regex.Replace(input, evaluator, count)` overload to touch only the first (version-info) table.
3. **Bonus:** `Set-Content -Encoding utf8` prepends a BOM to `VERSION` on WinPS 5.1 (spurious churn). Pinned it to a BOM-less UTF-8 + LF write.

## Verification
`release.ps1 prepare -Version 1.2.0` then `verify -Version 1.2.0 -Build` now run clean on WinPS 5.1: no garbage rows (ko/en manifests keep exactly one date row), `VERSION` stays BOM-less, both zip archives build, idempotent (no content churn). No framework-content or version change — scripts only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)